### PR TITLE
exlude tango from rdmd builds

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -10,6 +10,6 @@ if "%1"=="release" (
 	set extra_flags=-debug -g
 )
 
-rdmd -Imambo -Jresources -L+tango -Jresources --build-only -ofbin\dvm.exe %extra_flags% %args% dvm\dvm\dvm.d
+rdmd --exclude=tango -Imambo -Jresources -L+tango -Jresources --build-only -ofbin\dvm.exe %extra_flags% %args% dvm\dvm\dvm.d
 
 endlocal

--- a/build.sh
+++ b/build.sh
@@ -18,4 +18,4 @@ else
 	extra_flags="-debug -g"
 fi
 
-rdmd -Imambo -Jresources -L-lz -L-ltango --build-only -ofbin/dvm $extra_flags $extra_linker_flags "$@" dvm/dvm/dvm.d
+${RDMD:-rdmd} --exclude=tango -Imambo -Jresources -L-lz -L-ltango --build-only -ofbin/dvm $extra_flags $extra_linker_flags "$@" dvm/dvm/dvm.d


### PR DESCRIPTION
- also allow to set RDMD via env
